### PR TITLE
pass sourceMap option to babel

### DIFF
--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -53,7 +53,10 @@ module.exports = function(grunt) {
 
       return rollup.rollup({
         entry: entry,
-        external: options.external
+        external: options.external,
+        babel: {
+          sourceMap: options.sourceMap
+        }
       }).then(function(bundle) {
 
         var sourceMapFile = options.sourceMapFile;


### PR DESCRIPTION
Should fix sourcemap issue (https://github.com/rollup/rollup-babel/issues/1#issuecomment-148539751) – Babel won't generate a sourcemap unless it's told to, meaning that when Rollup tries to collapse sourcemaps, it can't find one. Next version of Rollup will have a more informative error message, incidentally
